### PR TITLE
added hexToRgb function

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -1,6 +1,15 @@
 
 
 module.exports = {
+  
+  hexToRgb: function hexToRgb(hex) {
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16)
+    } : null;
+  },
 
   rgbToHsv: function rgbToHsv(r, g, b) {
     r /= 0xFF;

--- a/test/v6.js
+++ b/test/v6.js
@@ -200,6 +200,11 @@ describe("Testing transmission of control sequences", function () {
     done();
   });
 
+  it("shall transform HEX to RGB", function (done) {
+    expect(index.helper.hexToRgb('#007aff')).toBe({r: 0, g: 122, b:255});
+    done();    
+  });
+
   it("shall transform HSV hue to milight hue", function (done) {
     expect(index.helper.hsvToMilightColor([359, 0, 0])).toBe(178);
     done();


### PR DESCRIPTION
Takes the 6-digit hex code for colors (eg. #FFFFFF). Might be useful to someone, I didn't see it in the library, if it exists ignore this pull request, otherwise, could be a nice addition to the current converting functions.