### PR TITLE
Return Promise to quiet node.js warning about runaway promise

### DIFF
--- a/src/milight-v6-mixin.js
+++ b/src/milight-v6-mixin.js
@@ -44,7 +44,7 @@ var milightV6Mixin = function() {
         ]).then(function (response) {
           self._sessionId = response.slice(19, 21);
           helper.debug('Session Id: ' + helper.buffer2hex(self._sessionId));
-          Promise.delay(self.delayBetweenCommands).then(function () {
+          return Promise.delay(self.delayBetweenCommands).then(function () {
             resolve(self._sessionId)
           })
         }).catch(function (error) {


### PR DESCRIPTION
I realize this doesn't do anything because the Promise is never used later. I like to leave the warnings on in case I misuse Promises in my own code, I'd prefer not to have this spurious warning.